### PR TITLE
Remove stopsound because it can't be run on client

### DIFF
--- a/lua/autorun/server/sv_autoclean.lua
+++ b/lua/autorun/server/sv_autoclean.lua
@@ -4,8 +4,7 @@ local DEFAULT_CLEAN_INTERVAL_IN_SECONDS = "500"
 CreateConVar("cfc_autoclean", DEFAULT_CLEAN_INTERVAL_IN_SECONDS, ConVarFlags, "Autocleans the server based on seconds given")
 
 local CleanupCommands = {
-    ["r_cleardecals"] = true,
-    ["stopsound"] = true
+    ["r_cleardecals"] = true
 }
 
 local function notifyPlayers( count )


### PR DESCRIPTION
This is throwing an err in console every time it's run because apparently we can't force clients to run this command 🤷‍♂ 